### PR TITLE
feat: scaffold Godot hello-world mobile app baseline

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -13,10 +13,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Godot
-        run: |
-          sudo snap install godot --classic
-          godot --version
+      - name: Setup Godot 4.2.2
+        uses: firebelley/setup-godot@v1
+        with:
+          version: 4.2.2
+          install-templates: false
+
+      - name: Show Godot version
+        run: godot --version
 
       - name: Run headless tests
         run: godot --headless --path . --script res://tests/run_tests.gd

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -13,11 +13,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Godot 4.2.2
-        uses: firebelley/setup-godot@v1
-        with:
-          version: 4.2.2
-          install-templates: false
+      - name: Install Godot 4.2.2
+        run: |
+          GODOT_VERSION="4.2.2"
+          GODOT_ZIP="Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip"
+          GODOT_URL="https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-stable/${GODOT_ZIP}"
+
+          curl -L --fail "$GODOT_URL" -o "$GODOT_ZIP"
+          unzip -q "$GODOT_ZIP"
+          chmod +x "Godot_v${GODOT_VERSION}-stable_linux.x86_64"
+          sudo mv "Godot_v${GODOT_VERSION}-stable_linux.x86_64" /usr/local/bin/godot
 
       - name: Show Godot version
         run: godot --version

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,35 @@
+name: Mobile CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Godot
+        run: |
+          sudo snap install godot --classic
+          godot --version
+
+      - name: Run headless tests
+        run: godot --headless --path . --script res://tests/run_tests.gd
+
+  release-plan:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Explain release handoff
+        run: |
+          echo "Tag detected: $GITHUB_REF"
+          echo "Next step: run platform export jobs with signing secrets for Android and iOS."

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.import/
+.export/
+.godot/
+*.translation
+*.tmp

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/tower-defense.iml" filepath="$PROJECT_DIR$/.idea/tower-defense.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/tower-defense.iml
+++ b/.idea/tower-defense.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Tower Defense – Hello World (Godot)
+
+Diese Version liefert ein lauffähiges Grundgerüst als mobile-first Hello-World-App in Godot.
+
+## Projekt starten
+1. Projekt in Godot 4.2+ öffnen.
+2. `main_menu.tscn` wird automatisch als Startszene geladen.
+
+## Enthalten
+- Basis-Projektkonfiguration für mobile Darstellung
+- UI-Startszene mit Safe-Area-Abständen
+- Minimaler Test-Runner für Kernkonstanten
+- CI-Workflow als Deployment-Grundlage
+
+Weiterführende Details:
+- `docs/PROJECT_STRUCTURE.md`
+- `docs/TESTING.md`
+- `docs/DEPLOYMENT.md`

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,25 @@
+# Deployment-Prozess (iOS + Android)
+
+## Branching
+- `main`: produktionsnah, nur über PR.
+- Feature-Branches: kleine, nachvollziehbare Änderungen.
+
+## Pipeline-Stufen
+1. **Validate**
+   - Unit-Tests headless laufen.
+2. **Build-Check**
+   - Android-Export im CI (Debug/Release-Template je nach Secrets).
+   - iOS-Export als Projekt-/Xcode-Artefakt zur Weiterverarbeitung.
+3. **Release**
+   - Tags (`v*`) triggern Release-Job.
+   - Artefakte werden bereitgestellt (APK/AAB, iOS Export-Bundle).
+
+## Manuelle Release-Checkliste
+1. Start, Menü, Touch-Bedienung prüfen.
+2. Performance-Baseline auf Mid-Range-Geräten prüfen.
+3. Store-Metadaten, Privacy-Formulare und Berechtigungen abgleichen.
+4. Signierte Builds in App Store Connect / Play Console hochladen.
+
+## Hinweise
+- Signaturdaten und Store-Credentials ausschließlich über CI-Secrets verwalten.
+- Keine zusätzlichen Berechtigungen ohne Produkt- und Privacy-Freigabe einführen.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,0 +1,22 @@
+# Ordnerstruktur (MVP)
+
+```text
+.
+├── .github/workflows/          # CI/CD-Pipelines
+├── docs/                       # Prozess- und Architektur-Dokumentation
+├── scenes/
+│   └── ui/                     # UI-Szenen (Start, HUD, Menüs)
+├── scripts/
+│   ├── core/                   # Globale Konstanten und Basislogik
+│   └── ui/                     # UI-spezifische Logik
+├── tests/
+│   ├── run_tests.gd            # Headless Test-Runner
+│   └── unit/                   # Unit-Tests
+├── project.godot               # Godot-Projektkonfiguration
+└── README.md
+```
+
+## Strukturprinzipien
+- Feature-orientierte Trennung zwischen `scenes` und `scripts`.
+- Mobile-relevante UI in `scenes/ui` gebündelt.
+- Tests liegen separat unter `tests`, damit sie in CI headless ausführbar sind.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,22 @@
+# Testkonzept (Hello World MVP)
+
+## Ziel
+Sicherstellen, dass die App auch in frühen Projektphasen reproduzierbar startet und zentrale Texte/Konstanten korrekt gesetzt sind.
+
+## Testarten
+1. **Unit-Tests (headless):**
+   - Validieren Kernkonstanten (`AppConstants`) und Basisannahmen.
+2. **Smoke-Test (manuell im Editor):**
+   - Startszene lädt.
+   - Hello-World-Text und Version sind sichtbar.
+   - Button ist touch-freundlich groß.
+
+## Ausführung lokal
+Voraussetzung: Godot 4.2+ im PATH (Befehl `godot`).
+
+```bash
+godot --headless --path . --script res://tests/run_tests.gd
+```
+
+## CI-Anforderung
+Der gleiche headless-Test wird in der Pipeline ausgeführt und blockiert Deployments bei Fehlschlägen.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,19 @@
+; Engine configuration file.
+; Godot 4 project bootstrap for mobile-first tower defense.
+
+config_version=5
+
+[application]
+config/name="Tower Defense"
+run/main_scene="res://scenes/ui/main_menu.tscn"
+config/features=PackedStringArray("4.2")
+
+[display]
+window/size/viewport_width=1080
+window/size/viewport_height=1920
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
+
+[rendering]
+renderer/rendering_method="mobile"
+textures/vram_compression/import_etc2_astc=true

--- a/project.godot
+++ b/project.godot
@@ -1,19 +1,31 @@
 ; Engine configuration file.
-; Godot 4 project bootstrap for mobile-first tower defense.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
+
 config/name="Tower Defense"
 run/main_scene="res://scenes/ui/main_menu.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.6")
 
 [display]
+
 window/size/viewport_width=1080
 window/size/viewport_height=1920
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
 [rendering]
+
 renderer/rendering_method="mobile"
 textures/vram_compression/import_etc2_astc=true

--- a/scenes/ui/main_menu.tscn
+++ b/scenes/ui/main_menu.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/main_menu.gd" id="1_main"]
+
+[node name="MainMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_main")
+
+[node name="SafeAreaContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 40.0
+offset_top = 80.0
+offset_right = -40.0
+offset_bottom = -80.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBox" type="VBoxContainer" parent="SafeAreaContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+theme_override_constants/separation = 24
+
+[node name="TitleLabel" type="Label" parent="SafeAreaContainer/VBox"]
+layout_mode = 2
+text = "Tower Defense"
+horizontal_alignment = 1
+
+[node name="HelloLabel" type="Label" parent="SafeAreaContainer/VBox" unique_name_in_owner = true]
+layout_mode = 2
+text = "Hello World"
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="VersionLabel" type="Label" parent="SafeAreaContainer/VBox" unique_name_in_owner = true]
+layout_mode = 2
+text = "v0.0.0"
+horizontal_alignment = 1
+
+[node name="StartButton" type="Button" parent="SafeAreaContainer/VBox"]
+layout_mode = 2
+custom_minimum_size = Vector2(0, 96)
+text = "Start (MVP Placeholder)"

--- a/scenes/ui/main_menu.tscn
+++ b/scenes/ui/main_menu.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene format=3 uid="uid://7bwminawon8p"]
 
-[ext_resource type="Script" path="res://scripts/ui/main_menu.gd" id="1_main"]
+[ext_resource type="Script" uid="uid://bstcyuuyi6m1e" path="res://scripts/ui/main_menu.gd" id="1_main"]
 
-[node name="MainMenu" type="Control"]
+[node name="MainMenu" type="Control" unique_id=656955348]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -11,7 +11,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_main")
 
-[node name="SafeAreaContainer" type="MarginContainer" parent="."]
+[node name="SafeAreaContainer" type="MarginContainer" parent="." unique_id=633554566]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -23,28 +23,28 @@ offset_bottom = -80.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="VBox" type="VBoxContainer" parent="SafeAreaContainer"]
+[node name="VBox" type="VBoxContainer" parent="SafeAreaContainer" unique_id=455409655]
 layout_mode = 2
 size_flags_vertical = 4
 theme_override_constants/separation = 24
 
-[node name="TitleLabel" type="Label" parent="SafeAreaContainer/VBox"]
+[node name="TitleLabel" type="Label" parent="SafeAreaContainer/VBox" unique_id=1999046251]
 layout_mode = 2
 text = "Tower Defense"
 horizontal_alignment = 1
 
-[node name="HelloLabel" type="Label" parent="SafeAreaContainer/VBox" unique_name_in_owner = true]
+[node name="HelloLabel" type="Label" parent="SafeAreaContainer/VBox" unique_id=1017183247]
 layout_mode = 2
 text = "Hello World"
 horizontal_alignment = 1
 autowrap_mode = 3
 
-[node name="VersionLabel" type="Label" parent="SafeAreaContainer/VBox" unique_name_in_owner = true]
+[node name="VersionLabel" type="Label" parent="SafeAreaContainer/VBox" unique_id=765569902]
 layout_mode = 2
 text = "v0.0.0"
 horizontal_alignment = 1
 
-[node name="StartButton" type="Button" parent="SafeAreaContainer/VBox"]
-layout_mode = 2
+[node name="StartButton" type="Button" parent="SafeAreaContainer/VBox" unique_id=2026104928]
 custom_minimum_size = Vector2(0, 96)
+layout_mode = 2
 text = "Start (MVP Placeholder)"

--- a/scripts/core/app_constants.gd
+++ b/scripts/core/app_constants.gd
@@ -1,0 +1,6 @@
+extends RefCounted
+class_name AppConstants
+
+const APP_TITLE: String = "Tower Defense"
+const HELLO_WORLD_TEXT: String = "Hello World – Tower Defense Mobile Prototype"
+const VERSION_TEXT: String = "v0.1.0-alpha"

--- a/scripts/core/app_constants.gd.uid
+++ b/scripts/core/app_constants.gd.uid
@@ -1,0 +1,1 @@
+uid://blllfy17anvlc

--- a/scripts/ui/main_menu.gd
+++ b/scripts/ui/main_menu.gd
@@ -1,0 +1,8 @@
+extends Control
+
+@onready var hello_label: Label = %HelloLabel
+@onready var version_label: Label = %VersionLabel
+
+func _ready() -> void:
+	hello_label.text = AppConstants.HELLO_WORLD_TEXT
+	version_label.text = AppConstants.VERSION_TEXT

--- a/scripts/ui/main_menu.gd
+++ b/scripts/ui/main_menu.gd
@@ -1,7 +1,7 @@
 extends Control
 
-@onready var hello_label: Label = %HelloLabel
-@onready var version_label: Label = %VersionLabel
+@onready var hello_label: Label = $SafeAreaContainer/VBox/HelloLabel
+@onready var version_label: Label = $SafeAreaContainer/VBox/VersionLabel
 
 func _ready() -> void:
 	hello_label.text = AppConstants.HELLO_WORLD_TEXT

--- a/scripts/ui/main_menu.gd.uid
+++ b/scripts/ui/main_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://bstcyuuyi6m1e

--- a/tests/run_tests.gd
+++ b/tests/run_tests.gd
@@ -1,0 +1,29 @@
+extends SceneTree
+
+const TEST_SCRIPTS: Array[Script] = [
+	preload("res://tests/unit/test_app_constants.gd")
+]
+
+func _initialize() -> void:
+	var total_failures: int = 0
+
+	for test_script: Script in TEST_SCRIPTS:
+		var test_instance: RefCounted = test_script.new()
+		var result: Dictionary = test_instance.run()
+		var failures: Array = result.get("failures", [])
+
+		if failures.is_empty():
+			print("PASS: %s" % result.get("name", test_script.resource_path))
+		else:
+			total_failures += failures.size()
+			print("FAIL: %s" % result.get("name", test_script.resource_path))
+			for failure: String in failures:
+				print("  - %s" % failure)
+
+	if total_failures > 0:
+		print("Tests failed: %d" % total_failures)
+		quit(1)
+		return
+
+	print("All tests passed")
+	quit(0)

--- a/tests/run_tests.gd.uid
+++ b/tests/run_tests.gd.uid
@@ -1,0 +1,1 @@
+uid://b5a03b21vyjt5

--- a/tests/unit/test_app_constants.gd
+++ b/tests/unit/test_app_constants.gd
@@ -1,0 +1,19 @@
+extends RefCounted
+class_name TestAppConstants
+
+func run() -> Dictionary:
+	var failures: Array[String] = []
+
+	if AppConstants.HELLO_WORLD_TEXT.is_empty():
+		failures.append("HELLO_WORLD_TEXT darf nicht leer sein")
+
+	if not AppConstants.HELLO_WORLD_TEXT.contains("Hello World"):
+		failures.append("HELLO_WORLD_TEXT muss 'Hello World' enthalten")
+
+	if not AppConstants.VERSION_TEXT.begins_with("v"):
+		failures.append("VERSION_TEXT muss mit 'v' starten")
+
+	return {
+		"name": "test_app_constants",
+		"failures": failures
+	}

--- a/tests/unit/test_app_constants.gd.uid
+++ b/tests/unit/test_app_constants.gd.uid
@@ -1,0 +1,1 @@
+uid://c47lgdq6argj7


### PR DESCRIPTION
### Motivation
- Provide a minimal, mobile-first Godot project scaffold to serve as a stable starting point for the Tower Defense mobile app. 
- Define a clear folder structure, basic UI, tests and documentation so further development follows consistent patterns. 
- Add a CI validation step to ensure headless tests run before any release workflow is triggered.

### Description
- Add `project.godot` with mobile-oriented display and rendering settings and `run/main_scene` set to `res://scenes/ui/main_menu.tscn`.
- Create a mobile-safe start scene `scenes/ui/main_menu.tscn` with title, `HelloLabel`, `VersionLabel` and a large `StartButton` and bind it to `scripts/ui/main_menu.gd`.
- Introduce core constants in `scripts/core/app_constants.gd` and a simple UI script `scripts/ui/main_menu.gd` to populate texts from `AppConstants`.
- Add a headless test runner `tests/run_tests.gd` and unit test `tests/unit/test_app_constants.gd`, documentation in `docs/`, `README.md`, `.gitignore`, and a GitHub Actions workflow `.github/workflows/mobile-ci.yml` that installs Godot and runs headless tests.

### Testing
- Local headless test attempted with `godot --headless --path . --script res://tests/run_tests.gd` and failed due to `godot` not being installed in the current environment (`command not found`).
- Static verification of created files and structure performed via repository inspection and status checks, confirming all new files are present.
- CI workflow (`.github/workflows/mobile-ci.yml`) is configured to install Godot via `snap` and run the same headless tests during validation, and should run tests successfully in a properly provisioned runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699df8496860832488a1a286f9bfc4f0)